### PR TITLE
Fix: update note conversion in InputProcessor to replace '4' with '2'

### DIFF
--- a/smdatatools/data_processing/input_processor.py
+++ b/smdatatools/data_processing/input_processor.py
@@ -8,7 +8,7 @@ from smdatatools.components.measure import Measure
 class InputProcessor:
     @staticmethod
     def convert_note(line: str) -> str:
-        return sub('4', '1', sub('[MKLF]', '0', line))    #replaces extra notes: M, K, L, F; replaces 4 note
+        return sub('4', '2', sub('[MKLF]', '0', line))    #replaces extra notes: M, K, L, F; replaces 4 note
 
     @staticmethod
     def parse_sm_input(sm_file: list[str]) -> tuple[dict[str, Any], bool]:


### PR DESCRIPTION
4 represents a roll which is more similar to a hold (2) than a tap (1). This an error where invalid charts were  being made where notes like

0040
0030

gets converted into

0010
0030

This is an error since taps should never have end after it in the same column.